### PR TITLE
CSS and JS are excluded extensions argument

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -9,7 +9,8 @@
 	<!-- Show progress and sniff codes in all reports -->
 	<arg value="ps"/>
 
-	<!-- Adds support for .phpcsignore -->
+	<!-- Adds support for .phpcsignore
+ 		https://github.com/squizlabs/PHP_CodeSniffer/issues/1884 -->
 	<autoload>./bootstrap.php</autoload>
 
 	<rule ref="WordPress-Core">
@@ -25,8 +26,7 @@
 
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
-	<exclude-pattern>*.js</exclude-pattern>
-	<exclude-pattern>*.css</exclude-pattern>
+	<exclude-pattern>*.min.*</exclude-pattern>
 
 	<!-- Allow . in hook names -->
 	<rule ref="WordPress.NamingConventions.ValidHookName">


### PR DESCRIPTION
Excluding CSS & JS files is not needed as we define the extensions list in `<arg name="extensions" value="php"/>`. Instead of making a change in two places we can just edit `<arg name="extensions" value="php"/>` to process CSS and JS files too if need be.

- Exclude the processing of minfied files. PHPCS normally skipps minifed files but this prevents it a step eariler.
- Add inline reference to PHPCS issue.