### PR TITLE
Define minimum supported WordPress version per sniff

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -51,36 +51,8 @@
 		</properties>
 	</rule>
 
-	<!-- Define minimum supported WordPress version per sniff so it's easier to override -->
-	<rule ref="WordPress.WP.DeprecatedFunctions">
-		<properties>
-			<property name="minimum_supported_version" value="4.9" />
-		</properties>
-	</rule>
-
-	<rule ref="WordPress.WP.AlternativeFunctions">
-		<properties>
-			<property name="minimum_supported_version" value="4.9" />
-		</properties>
-	</rule>
-
-	<rule ref="WordPress.WP.DeprecatedClasses">
-		<properties>
-			<property name="minimum_supported_version" value="4.9" />
-		</properties>
-	</rule>
-
-	<rule ref="WordPress.WP.DeprecatedParameters">
-		<properties>
-			<property name="minimum_supported_version" value="4.9" />
-		</properties>
-	</rule>
-
-	<rule ref="WordPress.WP.DeprecatedParameterValues">
-		<properties>
-			<property name="minimum_supported_version" value="4.9" />
-		</properties>
-	</rule>
+	<!--Require the latest version of WordPress. -->
+	<config name="minimum_supported_wp_version" value="4.9"/>
 
 	<!-- Run against the PHPCompatibilityWP ruleset -->
 	<rule ref="PHPCompatibilityWP"/>


### PR DESCRIPTION
The alternative would be just `<config name="minimum_supported_wp_version" value="4.9"/>`.

That one takes precedence over individual per-sniff config values, thus it makes it harder to override it for a certain sniff alone in a ruleset.

Fixes #11.