### PR TITLE
Allow short array syntax in our projects

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -25,6 +25,7 @@
 	<rule ref="WordPress-Core">
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
 	</rule>
 
 	<rule ref="WordPress-Docs">


### PR DESCRIPTION
This was included in `WordPress-Core` ruleset https://github.com/WordPress/WordPress-Coding-Standards/pull/1770