### PR TITLE
Add SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator.

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -137,6 +137,9 @@
 	<!-- Prohibits uses from the same namespace. -->
 	<rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
 
+	<!-- Requires use of null coalesce operator (??) when possible. -->
+	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
+
 	<!--Require the latest version of WordPress. -->
 	<config name="minimum_supported_wp_version" value="4.9"/>
 


### PR DESCRIPTION
Requires use of null coalesce operator (??) when possible. Rule supports automatic fixing .

Instead of
```
$bar = isset( $foo ) ? $foo : 'foo';
$bar = null !== $foo ? $foo : 'foo';
```

use
```
$bar = $foo ?? 'foo';
$bar = $foo ?? 'foo';
```