### PR TITLE
Add SlevomatCodingStandard.Classes.ModernClassNameReference.

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -137,6 +137,9 @@
 	<!-- Prohibits uses from the same namespace. -->
 	<rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
 
+	<!-- Class names should be referenced via ::class constant when possible. -->
+	<rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
+
 	<!--Require the latest version of WordPress. -->
 	<config name="minimum_supported_wp_version" value="4.9"/>
 


### PR DESCRIPTION
Class names should be referenced via ::class constant when possible. Rule supports automatic fixing .

Instead of
```
$bar = get_class( $this );
```
use
```
$bar = static::class;
```