### PR TITLE
Add SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions.

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -136,6 +136,8 @@
 	</rule>
 	<!-- Prohibits uses from the same namespace. -->
 	<rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
+	<!-- All references to types named Exception or ending with Exception must be referenced via a fully qualified name. -->
+	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions"/>
 
 	<!--Require the latest version of WordPress. -->
 	<config name="minimum_supported_wp_version" value="4.9"/>


### PR DESCRIPTION
All references to types named Exception or ending with Exception must be referenced via a fully qualified name. Rule supports automatic fixing.

See https://github.com/slevomat/coding-standard#slevomatcodingstandardnamespacesfullyqualifiedexceptions- for an example.