### PR TITLE
Add SlevomatCodingStandard.Commenting.ForbiddenAnnotations.

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -145,6 +145,19 @@
 	<!-- Requires use of null coalesce operator (??) when possible. -->
 	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
 
+	<!-- Reports forbidden annotations. -->
+	<rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations">
+		<properties>
+			<property name="forbiddenAnnotations" type="array">
+				<element value="@package"/>
+				<element value="@author"/>
+				<element value="@created"/>
+				<element value="@copyright"/>
+				<element value="@license"/>
+			</property>
+		</properties>
+	</rule>
+
 	<!--Require the latest version of WordPress. -->
 	<config name="minimum_supported_wp_version" value="4.9"/>
 


### PR DESCRIPTION
Reports forbidden annotations. Rule supports automatic fixing.

See https://github.com/slevomat/coding-standard#slevomatcodingstandardcommentingforbiddenannotations-

I did not include `@version` and `@throws` for now but we can add it if someone has strong feelings about it.