### PR TITLE
Add SlevomatCodingStandard.Namespaces.UnusedUses.

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -138,6 +138,8 @@
 	<rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
 	<!-- All references to types named Exception or ending with Exception must be referenced via a fully qualified name. -->
 	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions"/>
+	<!-- Looks for unused imports from other namespaces. -->
+	<rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
 
 	<!-- Class names should be referenced via ::class constant when possible. -->
 	<rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>


### PR DESCRIPTION
Looks for unused imports from other namespaces. Rule supports automatic fixing.
https://github.com/slevomat/coding-standard#slevomatcodingstandardnamespacesunuseduses-