### PR TITLE
Exclude WordPress.PHP.DisallowShortTernary.

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -26,6 +26,7 @@
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+		<exclude name="WordPress.PHP.DisallowShortTernary"/>
 	</rule>
 
 	<rule ref="WordPress-Docs">


### PR DESCRIPTION
Allows to use something like `$foo = get_post_meta( $post_id, 'foo', true ) ?: ''`. I don't see why we shouldn't allow this on our coding standard.

The rule was added in https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/2.2.0.