### PR TITLE
Allow the use of json_encode().

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -82,11 +82,13 @@
 		</properties>
 	</rule>
 
-	<!-- Allow the use of filesystem functions. -->
 	<rule ref="WordPress.WP.AlternativeFunctions">
 		<properties>
 			<property name="exclude" type="array">
+				<!-- Allow the use of filesystem functions. -->
 				<element value="file_get_contents"/>
+				<!-- wp_json_encode() is nowadays only a simple wrapper for json_encode(). -->
+				<element value="json_encode"/>
 			</property>
 		</properties>
 	</rule>


### PR DESCRIPTION
wp_json_encode() is nowadays only a simple wrapper for json_encode(), see https://github.com/WordPress/wordpress-develop/blob/ba17e29f25ee6ccdc8375cd072db05835be2a6a2/src/wp-includes/functions.php#L3807.