### PR TITLE
Add SlevomatCodingStandard.TypeHints.LongTypeHints.

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -107,6 +107,8 @@
 			<property name="spacesCountBeforeColon" value="0"/>
 		</properties>
 	</rule>
+	<!-- Enforces using shorthand scalar typehint variants in phpDocs. -->
+	<rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
 
 	<!-- Disallows grouped use declarations. -->
 	<rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>


### PR DESCRIPTION
Enforces using shorthand scalar typehint variants in phpDocs. Rule supports automatic fixing.

This is already [part of the WordPress coding standard](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#phpdoc-tags) but not enforced yet. See https://github.com/slevomat/coding-standard#slevomatcodingstandardtypehintslongtypehints-. 