### PR TITLE
Add @access and @version to forbidden annotations.

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -159,6 +159,8 @@
 				<element value="@created"/>
 				<element value="@copyright"/>
 				<element value="@license"/>
+				<element value="@access"/>
+				<element value="@version"/>
 			</property>
 		</properties>
 	</rule>


### PR DESCRIPTION
Follow-up to #49.

* `@version`  shouldn't be used.`@since` is still okay, but probably only in public plugins.
* `@access` shouldn't be used, use the keywords instead.