### PR TITLE
Require root namespace for special compiled PHP functions

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -146,6 +146,12 @@
 	<!-- <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions"/> -->
 	<!-- Looks for unused imports from other namespaces. Temporarily disabled due to performance issues. -->
 	<!-- <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/> -->
+	<!-- Require root namespace for special compiled PHP functions. -->
+	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions">
+		<properties>
+			<property name="includeSpecialFunctions" value="true"/>
+		</properties>
+	</rule>
 
 	<!-- Class names should be referenced via ::class constant when possible. -->
 	<rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>


### PR DESCRIPTION
Adds the `SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions` rule with `includeSpecialFunctions` set. Includes auto-fixer. 

Requires 6.2.0 of Slevomat Coding Standard.

Fixes #60.