### PR TITLE
Require specific order of PHPDoc annotations

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -167,6 +167,31 @@
 			</property>
 		</properties>
 	</rule>
+	<!-- Require specific order of PHPDoc annotations with empty newline between specific groups. -->
+	<rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
+		<properties>
+			<property name="linesCountBeforeFirstContent" value="0"/>
+			<property name="linesCountAfterLastContent" value="0"/>
+			<property name="linesCountBetweenDescriptionAndAnnotations" value="1"/>
+			<property name="linesCountBetweenAnnotationsGroups" value="1"/>
+			<property name="annotationsGroups" type="array">
+				<element value="@internal"/>
+				<element value="
+					@since,
+					@deprecated,
+				"/>
+				<element value="
+					@link,
+					@see,
+					@uses,
+				"/>
+				<element value="
+					@param,
+					@return,
+				"/>
+			</property>
+		</properties>
+	</rule>
 
 	<!--Require the latest version of WordPress. -->
 	<config name="minimum_supported_wp_version" value="4.9"/>


### PR DESCRIPTION
Adds the `SlevomatCodingStandard.Commenting.DocCommentSpacing` rule. Rule supports automatic fixing.

See https://github.com/slevomat/coding-standard#slevomatcodingstandardcommentingdoccommentspacing-.

Correct example:

```php
/**
 * Sends notification for an extended job listing.
 *
 * @internal Foo.
 *
 * @since 1.0.0
 * @deprecated 2.0.0
 *
 * @link https://google.de
 * @see get_the_title()
 * @uses get_permalink()
 *
 * @param int $job_id Post ID of the job listing.
 * @return bool True on success, false on failure.
 */
```