### PR TITLE
Allow file_put_contents and readfile

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -89,7 +89,8 @@
 		<properties>
 			<property name="exclude" type="array">
 				<!-- Allow the use of filesystem functions. -->
-				<element value="file_get_contents,file_put_contents,readfile"/>
+				<element value="file_get_contents"/>
+				<element value="file_system_read"/>
 				<!-- wp_json_encode() is nowadays only a simple wrapper for json_encode(). -->
 				<element value="json_encode"/>
 			</property>

--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -89,7 +89,7 @@
 		<properties>
 			<property name="exclude" type="array">
 				<!-- Allow the use of filesystem functions. -->
-				<element value="file_get_contents"/>
+				<element value="file_get_contents,file_put_contents,readfile"/>
 				<!-- wp_json_encode() is nowadays only a simple wrapper for json_encode(). -->
 				<element value="json_encode"/>
 			</property>


### PR DESCRIPTION
The use of `WP_Filesystem` is not everytime the go to way.