### PR TITLE
Allow @global annotation in PHPDoc

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -195,6 +195,9 @@
 					@uses,
 				"/>
 				<element value="
+					@global,
+				"/>
+				<element value="
 					@param,
 					@return,
 				"/>


### PR DESCRIPTION
Example:

```php
	/**
	 * Retrieves media content.
	 *
	 * @global \WP_Embed $wp_embed
	 *
	 * @return array {
	 *     Media data. Values will be empty if not supplied.
	 *
	 *     @type array $podcasts List of HTML embed code for podcasts.
	 *     @type array $videos   List of HTML embed code for videos.
	 * }
	 */
```