### PR TITLE
Disable Generic.Commenting.DocComment.MissingShort

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -202,6 +202,11 @@
 		</properties>
 	</rule>
 
+	<rule ref="Generic.Commenting.DocComment.MissingShort">
+		<!-- Temporarily disabled until https://github.com/WordPress/WordPress-Coding-Standards/issues/403 is fixed. -->
+		<severity>0</severity>
+	</rule>
+
 	<!--Require the latest version of WordPress. -->
 	<config name="minimum_supported_wp_version" value="4.9"/>
 


### PR DESCRIPTION
Temporarily disabled until https://github.com/WordPress/WordPress-Coding-Standards/issues/403 is fixed.

Fixes #65.