### PR TITLE
Add stylelint-config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,9 +7,9 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{*.md}]
+[*.md]
 trim_trailing_whitespace = false
 
-[{*.json}]
+[*.json]
 indent_style = space
 indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+* [@wearerequired/eslint-config](https://www.npmjs.com/package/@wearerequired/eslint-config) for linting JavaScript files.
+* [@wearerequired/stylelint-config](https://www.npmjs.com/package/@wearerequired/stylelint-config) for linting (S)CSS files.
+
 ## [1.4.1] - 2020-05-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 required coding standard for PHP, inspired by the [Human Made Coding Standards](https://github.com/humanmade/coding-standards) project.
 
-For the JavaScript coding standard head over to [@wearerequired/eslint-config](packages/eslint-config).
+For the JavaScript coding standard head over to [@wearerequired/eslint-config](packages/eslint-config).  
+For the (S)CSS coding standard head over to [@wearerequired/stylelint-config](packages/stylelint-config).
 
 ## Setup
 

--- a/packages/stylelint-config/.eslintrc
+++ b/packages/stylelint-config/.eslintrc
@@ -1,0 +1,3 @@
+{
+	"extends": [ "@wearerequired/eslint-config" ]
+}

--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -1,0 +1,21 @@
+# required (S)CSS Coding Standard
+
+required coding standard for (S)CSS, based on the rules provided by [`stylelint-config-wordpress`](https://github.com/WordPress-Coding-Standards/stylelint-config-wordpress).
+
+## Installation
+
+This package is an ESLint shareable configuration and requires `stylelint` and `stylelint-config-wordpress` to be installed. To install this config and the peerDependencies run:
+
+```bash
+npx install-peerdeps --dev @wearerequired/stylelint-config@latest
+```
+
+## Usage
+
+To opt-in to the default configuration, extend your own project's `.stylelintrc` file:
+
+```json
+{
+	"extends": [ "@wearerequired/stylelint-config" ]
+}
+```

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -1,0 +1,41 @@
+module.exports = {
+	extends: 'stylelint-config-wordpress',
+	rules: {
+		'max-line-length': 100,
+		'max-empty-lines': 1,
+		'rule-empty-line-before': [
+			'always',
+			{
+				except: [ 'first-nested' ],
+				ignore: [ 'after-comment' ],
+			},
+		],
+		'comment-empty-line-before': [
+			'always',
+			{
+				except: [ 'first-nested' ],
+				ignore: [ 'stylelint-commands' ],
+			},
+		],
+		'at-rule-empty-line-before': [
+			'always',
+			{
+				except: [ 'blockless-after-blockless', 'first-nested' ],
+				ignore: [ 'after-comment' ],
+			},
+		],
+		'media-feature-parentheses-space-inside': 'always',
+		'function-parentheses-space-inside': 'always-single-line',
+		'function-comma-space-after': 'always-single-line',
+		'number-leading-zero': 'never',
+		'selector-class-pattern': [
+			// See https://en.bem.info/methodology/naming-convention/#two-dashes-style.
+			'^(?<block>(?:[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)(?<element>(?:__[a-z][a-z0-9]*(?:-[a-z0-9]+)*))?(?<modifier>(?:--[a-z][a-z0-9]*)(?:-[a-z0-9]+)*)?$',
+			{
+				resolveNestedSelectors: true,
+				message:
+					"Selector should use lowercase and hyphens to separate words or in BEM style: block-name__elem-name--mod-name (selector-class-pattern)'",
+			},
+		],
+	},
+};

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -34,7 +34,7 @@ module.exports = {
 			{
 				resolveNestedSelectors: true,
 				message:
-					"Selector should use lowercase and hyphens to separate words or in BEM style: block-name__elem-name--mod-name (selector-class-pattern)'",
+					'Selector should use lowercase and hyphens to separate words or in BEM style: block-name__elem-name--mod-name (selector-class-pattern)',
 			},
 		],
 	},

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@wearerequired/stylelint-config",
+  "version": "1.5.0-alpha.1",
+  "description": "required coding standard for (S)CSS.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wearerequired/coding-standards.git"
+  },
+  "keywords": [
+    "stylelint",
+    "stylelintrc",
+    "config"
+  ],
+  "author": "required gmbh",
+  "license": "GPL-2.0-or-later",
+  "bugs": {
+    "url": "https://github.com/wearerequired/coding-standards/issues"
+  },
+  "homepage": "https://github.com/wearerequired/coding-standards/tree/master/packages/stylelint-config#readme",
+  "devDependencies": {
+    "@wearerequired/eslint-config": "^1.5.0 || ^1.5.0-beta",
+    "@wordpress/eslint-plugin": "^6.0.0",
+    "eslint": "^7.0.0",
+    "stylelint": "^13.0.0",
+    "stylelint-config-wordpress": "^16.0.0"
+  },
+  "peerDependencies": {
+    "stylelint-config-wordpress": "^16.0.0",
+    "stylelint": "^13.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
Fixes #77.

Package: https://www.npmjs.com/package/@wearerequired/stylelint-config

Extends `stylelint-config-wordpress` with some changes:

* Adjusts selector-class-pattern for BEM support
* Removes requirements for empty lines
* Sets line length to 100 as done for JS (#78)