### PR TITLE
Add introduction to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
-# required PHP Coding Standard
+# required Coding Standards
 
-required coding standard for PHP, inspired by the [Human Made Coding Standards](https://github.com/humanmade/coding-standards) project.
+The required coding standards represent the best practices for enabling a consistent code style across the team. The standards do not only contain stylistic rules. They are also defined to prevent potential security vulnerabilities or to leverage more modern syntax for enhanced performance.  
+This project is inspired by the [Human Made Coding Standards](https://github.com/humanmade/coding-standards) project.
 
 For the JavaScript coding standard head over to [@wearerequired/eslint-config](packages/eslint-config).  
 For the (S)CSS coding standard head over to [@wearerequired/stylelint-config](packages/stylelint-config).
 
-## Setup
+Please contact the handbook if you need help with [setting up the coding standards in your environment](https://handbook.required.com/development/coding-standards/).
+
+## required PHP Coding Standard
+
+### Setup
 
 1. `composer require --dev dealerdirect/phpcodesniffer-composer-installer wearerequired/coding-standards`
 2. Run the standards checks using the following command:
@@ -37,7 +42,7 @@ script:
 
 After that, run `composer lint` to run the standards checks and `composer format` to try auto-fixing of errors and warnings.
 
-### Excluding Files
+#### Excluding Files
 
 This standard includes special support for a `.phpcsignore` file (in the future, this should be [built into phpcs itself](https://github.com/squizlabs/PHP_CodeSniffer/issues/1884)). You can place a `.phpcsignore` file in your root directory (wherever you're going to run `phpcs` from).
 
@@ -55,13 +60,18 @@ Note that the patterns should match [the PHP_CodeSniffer style](https://github.c
 
 Patterns are relative to the directory that the `.phpcsignore` file lives in. On load, they are translated to absolute patterns: e.g. `*/tests/*` in `/your/dir/.phpcsignore` will become `/your/dir/.*/tests/.*` as a regular expression. **This differs from the regular PHP_CodeSniffer practice.**
 
-### Advanced/Extending
+#### Advanced/Extending
 
 You can create your own custom standard file (e.g. `phpcs.xml.dist`) if you want to extend these coding standards:
 
 ```xml
 <?xml version="1.0"?>
-<ruleset>
+<ruleset name="Custom Standard">
+	<description>Project specific coding standard.</description>
+
+	<!-- Files or directories to check -->
+	<file>.</file>
+
 	<!-- Use required Coding Standards -->
 	<rule ref="Required"/>
 
@@ -72,10 +82,45 @@ You can create your own custom standard file (e.g. `phpcs.xml.dist`) if you want
 You can then reference this file when running phpcs:
 
 ```
-vendor/bin/phpcs .
+vendor/bin/phpcs
 ```
 
-## Included Checks
+An example for a custom rule is to validate the text domain:
+
+```xml
+<rule ref="WordPress.WP.I18n">
+	<properties>
+		<property name="text_domain" type="array">
+			<element value="plugin-name"/>
+		</property>
+	</properties>
+</rule>
+```
+
+or to ensure the correct prefix is used:
+
+```xml
+<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+	<properties>
+		<property name="prefixes" type="array">
+			<element value="Required\PluginName"/>
+			<element value="plugin_name"/>
+		</property>
+	</properties>
+</rule>
+```
+
+If the project is a WordPress theme you have to set the following rule:
+
+```xml
+<rule ref="WordPress.Files.FileName">
+	<properties>
+		<property name="is_theme" value="true" />
+	</properties>
+</rule>
+```
+
+### Included Checks
 
 The phpcs standard is based upon the `WordPress-Core`, `WordPress-Docs`, and `WordPress-Extra` rules from the [WordPress Coding Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards). It also uses [VariableAnalysis](https://github.com/sirbrillig/phpcs-variable-analysis) for problematic variable use and some `SlevomatCodingStandard` rules from the [Slevomat Coding Standard](https://github.com/slevomat/coding-standard). Most of the sniffs are also providing automatic errors fixing for `phpcbf`.
 
@@ -96,7 +141,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{*.md}]
+[*.md]
 trim_trailing_whitespace = false
 
 [{*.json,*.yml,.prettierrc,.babelrc}]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project is inspired by the [Human Made Coding Standards](https://github.com
 For the JavaScript coding standard head over to [@wearerequired/eslint-config](packages/eslint-config).  
 For the (S)CSS coding standard head over to [@wearerequired/stylelint-config](packages/stylelint-config).
 
-Please contact the handbook if you need help with [setting up the coding standards in your environment](https://handbook.required.com/development/coding-standards/).
+For team members: Please contact our internal handbook if you need help with [setting up the coding standards in your environment](https://handbook.required.com/development/coding-standards/).
 
 ## required PHP Coding Standard
 
@@ -66,7 +66,7 @@ You can create your own custom standard file (e.g. `phpcs.xml.dist`) if you want
 
 ```xml
 <?xml version="1.0"?>
-<ruleset name="Custom Standard">
+<ruleset name="Project Standard">
 	<description>Project specific coding standard.</description>
 
 	<!-- Files or directories to check -->


### PR DESCRIPTION
This reformats the readme a bit with a small introduction, a link to the [new handbook pages](https://handbook.required.com/development/coding-standards/). It also updates the default PHPCS config and adds examples for custom rules.

Fixes #3.