### PR TITLE
Update ruleset for PHP 7.4 

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -115,6 +115,8 @@
 	</rule>
 	<!-- Enforces using shorthand scalar typehint variants in phpDocs. -->
 	<rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
+	<!-- Reports useless @var annotation for constants because the type of constant is always clear. -->
+	<rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
 
 	<!-- Disallows grouped use declarations. -->
 	<rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>

--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -120,6 +120,16 @@
 	<!-- Reports useless @var annotation for constants because the type of constant is always clear. -->
 	<rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
 
+	<!-- Enforces correct space usage in array functions. -->
+	<rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration">
+		<properties>
+			<property name="spacesCountAfterKeyword" value="0"/>
+			<property name="spacesCountBeforeArrow" value="1"/>
+			<property name="spacesCountAfterArrow" value="1"/>
+			<property name="allowMultiLine" value="true"/>
+		</properties>
+	</rule>
+
 	<!-- Disallows grouped use declarations. -->
 	<rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
 	<!-- Disallows leading backslash in use statement. -->

--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -215,7 +215,7 @@
 	</rule>
 
 	<!--Require the latest version of WordPress. -->
-	<config name="minimum_supported_wp_version" value="4.9"/>
+	<config name="minimum_supported_wp_version" value="5.3"/>
 
 	<!-- Run against the PHPCompatibilityWP ruleset -->
 	<rule ref="PHPCompatibilityWP"/>

--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -220,5 +220,5 @@
 	<!-- Run against the PHPCompatibilityWP ruleset -->
 	<rule ref="PHPCompatibilityWP"/>
 
-	<config name="testVersion" value="7.1-"/>
+	<config name="testVersion" value="7.4-"/>
 </ruleset>

--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -105,6 +105,8 @@
 
 	<!-- Requires return typehints and reports useless @return annotations. -->
 	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
+	<!-- Requires parameter typehints and reports useless @param annotations. -->
+	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
 	<!-- Checks that there's no whitespace between a nullability symbol and a typehint. -->
 	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
 	<!-- Checks whether the nullablity ? symbol is present before each nullable and optional parameter. -->

--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -103,6 +103,8 @@
 		</properties>
 	</rule>
 
+	<!-- Requires return typehints and reports useless @return annotations. -->
+	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
 	<!-- Checks that there's no whitespace between a nullability symbol and a typehint. -->
 	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
 	<!-- Checks whether the nullablity ? symbol is present before each nullable and optional parameter. -->

--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -107,8 +107,6 @@
 	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
 	<!-- Requires parameter typehints and reports useless @param annotations. -->
 	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
-	<!-- Checks that there's no whitespace between a nullability symbol and a typehint. -->
-	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
 	<!-- Checks whether the nullablity ? symbol is present before each nullable and optional parameter. -->
 	<rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
 	<!-- Enforce no space between closing brace and colon of return typehint. -->
@@ -117,6 +115,8 @@
 			<property name="spacesCountBeforeColon" value="0"/>
 		</properties>
 	</rule>
+	<!-- Checks that there's no whitespace between a nullability symbol and a typehint. -->
+	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
 	<!-- Enforces using shorthand scalar typehint variants in phpDocs. -->
 	<rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
 	<!-- Reports useless @var annotation for constants because the type of constant is always clear. -->

--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -122,6 +122,8 @@
 	<!-- Reports useless @var annotation for constants because the type of constant is always clear. -->
 	<rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
 
+	<!-- Requires arrow functions if possible. -->
+	<rule ref="SlevomatCodingStandard.Functions.RequireArrowFunction"/>
 	<!-- Enforces correct space usage in array functions. -->
 	<rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration">
 		<properties>

--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -160,6 +160,8 @@
 
 	<!-- Class names should be referenced via ::class constant when possible. -->
 	<rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
+	<!-- Requires declaring visibility for class constants. -->
+	<rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
 
 	<!-- Requires use of null coalesce operator (??) when possible. -->
 	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>


### PR DESCRIPTION
Fixes #35.
Fixes #58.
Fixes #104.

* Increases `testVersion` for PHP Compatibility check to 7.4.
* Increases `minimum_supported_wp_version` to 5.3, the first version with support for PHP 7.4, see https://make.wordpress.org/core/2019/10/11/wordpress-and-php-7-4/.
* Adds [`SlevomatCodingStandard.TypeHints.ReturnTypeHint`](https://github.com/slevomat/coding-standard/tree/6.4.1#slevomatcodingstandardtypehintsreturntypehint-) and [`SlevomatCodingStandard.TypeHints.ParameterTypeHint`](https://github.com/slevomat/coding-standard/tree/6.4.1#slevomatcodingstandardtypehintsparametertypehintspacing-) to require type hints and to prevent useless @return/@param annotations
* Adds [`SlevomatCodingStandard.TypeHints.UselessConstantTypeHint`](https://github.com/slevomat/coding-standard/tree/6.4.1#slevomatcodingstandardtypehintsuselessconstanttypehint-) to prevent useless @var annotations because the type of constant is always clear.
* Adds [`SlevomatCodingStandard.Classes.ClassConstantVisibility`](https://github.com/slevomat/coding-standard/tree/6.4.1#slevomatcodingstandardclassesclassconstantvisibility-) to require declaring the visibility of class constants.
* Adds [`SlevomatCodingStandard.Functions.RequireArrowFunction`](https://github.com/slevomat/coding-standard/tree/6.4.1#slevomatcodingstandardfunctionsrequirearrowfunction-) to require [short closures](https://stitcher.io/blog/short-closures-in-php) if possible. The format is defined by [`SlevomatCodingStandard.Functions.ArrowFunctionDeclaration`](https://github.com/slevomat/coding-standard/tree/6.4.1#slevomatcodingstandardfunctionsarrowfunctiondeclaration).
  Example:
  ```php
  add_filter( 'disable_months_dropdown', fn( string $post_type ): bool => self::NAME !== $post_type );
  ```


All new rules have automatic error fixing. An example can be seen [here](https://github.com/wearerequired/swisscom-ski-fan/commit/c1b54ccb6e315cfee33dee69be128c4afedb5932).