### PR TITLE
Change type of MissingTraversableTypeHintSpecification rule to warning

### DIFF
--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -104,12 +104,14 @@
 	</rule>
 
 	<!-- Requires return typehints and reports useless @return annotations. -->
-	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
-		<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification">
+		<type>warning</type>
 	</rule>
 	<!-- Requires parameter typehints and reports useless @param annotations. -->
-	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
-		<exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification">
+		<type>warning</type>
 	</rule>
 	<!-- Checks whether the nullablity ? symbol is present before each nullable and optional parameter. -->
 	<rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>

--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -104,9 +104,13 @@
 	</rule>
 
 	<!-- Requires return typehints and reports useless @return annotations. -->
-	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
+		<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
+	</rule>
 	<!-- Requires parameter typehints and reports useless @param annotations. -->
-	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
+		<exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
+	</rule>
 	<!-- Checks whether the nullablity ? symbol is present before each nullable and optional parameter. -->
 	<rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
 	<!-- Enforce no space between closing brace and colon of return typehint. -->


### PR DESCRIPTION
This disables the errors when using `array` instead of a more specific hint. Example:

![image](https://user-images.githubusercontent.com/617637/106004387-75668e80-60b3-11eb-9f5e-192148bf22e2.png)

I have used the ruleset since #110 and these rules are the most annoying so far. At the moment there appears to be no real benefit as the error can be suppressed by simply using `string[]` or `int[]` which might work in some cases but what if I have an array with strings and integers? How to define the type of the key when using associative arrays or what about multidimensional arrays?

I'm proposing to exclude the rules for now until we have clarified how the types should be documented.