### PR TITLE
Allow `@wordpress/eslint-plugin` v9 as dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2021-04-13
+
+### Changed
+* JS: Allow `@wordpress/eslint-plugin` v9 as dependency.
+
 ## [2.0.0] - 2021-02-26
 
 ### Changed

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/wearerequired/coding-standards/tree/master/packages/eslint-config#readme",
   "peerDependencies": {
-    "@wordpress/eslint-plugin": "^8",
+    "@wordpress/eslint-plugin": "^8 || ^9",
     "eslint": "^7"
   },
   "publishConfig": {


### PR DESCRIPTION
Fixes a dependency tree issue with npm@v7

![image](https://user-images.githubusercontent.com/617637/114569940-b400f380-9c75-11eb-8952-4cb4147b54bb.png)
