### PR TITLE
Add SCSS preset to stylelint config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+* CSS: Add SCSS preset for stylelint-config.
+
 ## [2.2.0] - 2021-07-15
 
 ### Changed

--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -20,6 +20,16 @@ module.exports = {
 };
 ```
 
+### SCSS Preset
+
+In addition to the default preset, there is also a SCSS preset. This preset extends both `@wearerequired/stylelint-config` and [`stylelint-config-recommended-scss`](https://github.com/stylelint-scss/stylelint-config-recommended-scss).
+
+```js
+module.exports = {
+	extends: [ '@wearerequired/stylelint-config/scss' ],
+};
+```
+
 <br>
 
 [![a required open source product - let's get in touch](https://media.required.com/images/open-source-banner.png)](https://required.com/en/lets-get-in-touch/)

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -27,5 +27,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "stylelint-config-recommended-scss": "^4.2.0",
+    "stylelint-scss": "^3.17.2"
   }
 }

--- a/packages/stylelint-config/scss.js
+++ b/packages/stylelint-config/scss.js
@@ -1,0 +1,32 @@
+module.exports = {
+	extends: [ './', 'stylelint-config-recommended-scss' ].map(
+		require.resolve
+	),
+
+	plugins: [ 'stylelint-scss' ],
+
+	rules: {
+		'at-rule-empty-line-before': [
+			'always',
+			{
+				except: [ 'blockless-after-blockless', 'first-nested' ],
+				ignore: [ 'after-comment' ],
+				ignoreAtRules: [ 'else' ],
+			},
+		],
+		'block-opening-brace-space-before': 'always',
+		'block-closing-brace-newline-after': [
+			'always',
+			{
+				ignoreAtRules: [ 'if', 'else' ],
+			},
+		],
+		'at-rule-name-space-after': 'always',
+		'scss/at-else-closing-brace-newline-after': 'always-last-in-chain',
+		'scss/at-else-closing-brace-space-after': 'always-intermediate',
+		'scss/at-else-empty-line-before': 'never',
+		'scss/at-if-closing-brace-newline-after': 'always-last-in-chain',
+		'scss/at-if-closing-brace-space-after': 'always-intermediate',
+		'scss/selector-no-redundant-nesting-selector': true,
+	},
+};


### PR DESCRIPTION
Fixes #93.

This does not `extend @wordpress/stylelint-config/scss` as this will override the custom rules added in `@wearerequired/stylelint-config` due to `@wordpress/stylelint-config/scss` extending `@wordpress/stylelint-config` too. Instead I opted in to copy the current rules from [`@wordpress/stylelint-config/scss`](https://github.com/WordPress/gutenberg/blob/3dcc403c42373fb2584c7a6baf5c93bf7148f365/packages/stylelint-config/scss.js).