### PR TITLE
Increase minimum peer dependency of `@wordpress/eslint-plugin` to ^10 and `eslint` to ^8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * PHP: Update slevomat/coding-standard from 7.0.12 to [7.0.18](https://github.com/slevomat/coding-standard/releases/tag/7.0.18).
 * PHP: Update phpcompatibility/phpcompatibility-wp from 2.1.1 to [2.1.3](https://github.com/PHPCompatibility/PHPCompatibilityWP/releases/tag/2.1.3).
 * PHP: Allow to install on PHP 8.
+* JS: Increase minimum peer dependency of `@wordpress/eslint-plugin` from 8/9 to 10.
+* JS: Increase minimum peer dependency of `eslint` from 7 to 8.
 
 ## [2.2.0] - 2021-07-15
 

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
   "private": true,
   "devDependencies": {
     "@wearerequired/eslint-config": "file:packages/eslint-config",
-    "@wordpress/eslint-plugin": "^9.0.5",
-    "eslint": "^7.26.0",
-    "lerna": "^4.0.0"
+    "@wordpress/eslint-plugin": "^10.0.0",
+    "eslint": "^8.8.0",
+    "lerna": "^4.0.0",
+    "prettier": "npm:wp-prettier@2.2.1-beta-1"
   },
   "scripts": {
     "publish:check": "lerna updated",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://github.com/wearerequired/coding-standards/tree/master/packages/eslint-config#readme",
   "peerDependencies": {
-    "@wordpress/eslint-plugin": "^8 || ^9",
-    "eslint": "^7"
+    "@wordpress/eslint-plugin": "^10",
+    "eslint": "^8"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fixes #168.