### PR TITLE
Increase minimum peer dependency of `@wordpress/stylelint-config` to ^20 and `stylelint` to ^14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * PHP: Update slevomat/coding-standard from 7.0.12 to [7.0.18](https://github.com/slevomat/coding-standard/releases/tag/7.0.18).
 * PHP: Update phpcompatibility/phpcompatibility-wp from 2.1.1 to [2.1.3](https://github.com/PHPCompatibility/PHPCompatibilityWP/releases/tag/2.1.3).
 * PHP: Allow to install on PHP 8.
-* JS: Increase minimum peer dependency of `@wordpress/eslint-plugin` from 8/9 to 10.
 * JS: Increase minimum peer dependency of `eslint` from 7 to 8.
+* JS: Increase minimum peer dependency of `@wordpress/eslint-plugin` from 8/9 to 10.
+* CSS: Increase minimum peer dependency of `stylelint` from 13 to 14.
+* CSS: Increase minimum peer dependency of `@wordpress/stylelint-config` from 19 to 20.
 
 ## [2.2.0] - 2021-07-15
 

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -22,14 +22,13 @@
   },
   "homepage": "https://github.com/wearerequired/coding-standards/tree/master/packages/stylelint-config#readme",
   "peerDependencies": {
-    "@wordpress/stylelint-config": "^19",
-    "stylelint": "^13"
+    "@wordpress/stylelint-config": "^20",
+    "stylelint": "^14"
   },
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "stylelint-config-recommended-scss": "^4.2.0",
-    "stylelint-scss": "^3.17.2"
+    "stylelint-config-recommended-scss": "^5.0.2"
   }
 }

--- a/packages/stylelint-config/scss.js
+++ b/packages/stylelint-config/scss.js
@@ -1,7 +1,5 @@
 module.exports = {
-	extends: [ './', 'stylelint-config-recommended-scss' ].map(
-		require.resolve
-	),
+	extends: [ './', 'stylelint-config-recommended-scss' ].map( require.resolve ),
 
 	plugins: [ 'stylelint-scss' ],
 


### PR DESCRIPTION
Fixes #167.