### PR TITLE
CSS: Allow to use currentColor as value keyword

### DIFF
--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -46,4 +46,10 @@ module.exports = {
 	],
 	// At-rules used by postcss-mixins.
 	'at-rule-no-unknown': [ true, { ignoreAtRules: [ 'define-mixin', 'mixin' ] } ],
+	'value-keyword-case': [
+		'lower',
+		{
+			camelCaseSvgKeywords: true,
+		},
+	],
 };


### PR DESCRIPTION
There was a change in Stylelint which we use to lint CSS which now highlights `currentColor` as an error because it should be `currentcolor`. For background see https://github.com/stylelint/stylelint/issues/4884 and https://github.com/stylelint/stylelint/issues/5863.
tldr;: The change was done to align with the [CSS level 4 spec](https://www.w3.org/TR/css-color-4/#currentcolor-color) and is already supported by all browsers.

The question is now: Should we follow the level 4 spec and start using `currentcolor` or continue with `currentColor`? If we want to do the later we can use the [`camelCaseSvgKeywords` setting](https://stylelint.io/user-guide/rules/list/value-keyword-case/#camelcasesvgkeywords-true--false-default-false) to restore the old behaviour as done in this PR.

@codiina @velthy @derpaschi @simulieren Which type do you prefer?