### PR TITLE
Replace jsxBracketSameLine option with bracketSameLine option

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -7,7 +7,7 @@ const prettierConfig = {
 	trailingComma: 'es5',
 	bracketSpacing: true,
 	parenSpacing: true,
-	jsxBracketSameLine: false,
+	bracketSameLine: false,
 	semi: true,
 	arrowParens: 'always',
 };


### PR DESCRIPTION
See https://prettier.io/blog/2021/09/09/2.4.0.html#replace-jsxbracketsameline-option-with-bracketsameline-option-11006httpsgithubcomprettierprettierpull11006-by-kurtztechhttpsgithubcomkurtztech.