### PR TITLE
Don't set minimum_supported_wp_version and testVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+* PHP: Remove `minimum_supported_wp_version` and `testVersion`.
+
 ## [4.0.0] - 2022-12-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ You can create your own custom standard file (e.g. `phpcs.xml.dist`) if you want
 	<!-- Use required Coding Standards -->
 	<rule ref="Required"/>
 
+	<!-- The minimum supported WordPress version for all sniffs which use it. -->
+	<config name="minimum_supported_wp_version" value="6.1"/>
+	<!-- The minimum PHP requirement. -->
+	<config name="testVersion" value="7.4-"/>
+
 	<!-- Your custom rules go here -->
 </ruleset>
 ```

--- a/Required/ruleset.xml
+++ b/Required/ruleset.xml
@@ -242,11 +242,6 @@
 		<severity>0</severity>
 	</rule>
 
-	<!--Require the latest version of WordPress. -->
-	<config name="minimum_supported_wp_version" value="5.3"/>
-
 	<!-- Run against the PHPCompatibilityWP ruleset -->
 	<rule ref="PHPCompatibilityWP"/>
-
-	<config name="testVersion" value="7.4-"/>
 </ruleset>


### PR DESCRIPTION
This removes the arbitrary default values for the supported WordPress and PHP requirements. Since these are per project those settings should be defined in the project specific config.