### PR TITLE
Add a strict PHPCS rulset which enfores declare( strict_types=1 )

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * PHP: Remove `minimum_supported_wp_version` and `testVersion`.
+* PHP: Introduce `Required-Strict` ruleset for stricter rules.
 
 ## [4.0.0] - 2022-12-08
 

--- a/Required-Strict/ruleset.xml
+++ b/Required-Strict/ruleset.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset name="Required-Strict">
+	<description>required Strict Coding Standards</description>
+
+	<!-- Include everything from the default set. -->
+	<rule ref="Required" />
+
+	<!-- Enforce having declare( strict_types=1 ) at the top of each PHP file. -->
+	<rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+		<properties>
+			<property name="declareOnFirstLine" value="false"/>
+			<property name="linesCountBeforeDeclare" value="1"/>
+			<property name="linesCountAfterDeclare" value="1"/>
+			<property name="spacesCountAroundEqualsSign" value="0"/>
+		</properties>
+	</rule>
+</ruleset>


### PR DESCRIPTION
This ruleset can be used to enforce stricter coding standards and can be used via `<rule ref="Required-Strict"/>` in a `phpcs.xml.dist` file. It will become the default for new projects.