### PR TITLE
Drop the redundant @babel/core dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@babel/core": "^7",
         "@changesets/cli": "^2.31.0",
         "@wordpress/eslint-plugin": "^25.0.0",
         "@wordpress/stylelint-config": "^23.0.0",
@@ -9590,20 +9589,20 @@
     },
     "packages/eslint-config": {
       "name": "@wearerequired/eslint-config",
-      "version": "6.0.1",
+      "version": "7.0.0-alpha.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "globals": "^16.0.0"
       },
       "peerDependencies": {
         "@wordpress/eslint-plugin": "^25.0.0",
-        "eslint": "^9.0.0",
+        "eslint": "^9.0.0 || ^10.0.0",
         "prettier": ">=3"
       }
     },
     "packages/stylelint-config": {
       "name": "@wearerequired/stylelint-config",
-      "version": "6.0.1",
+      "version": "7.0.0-alpha.0",
       "license": "GPL-2.0-or-later",
       "peerDependencies": {
         "@wordpress/stylelint-config": "^23",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "node": ">=20.19.0"
   },
   "devDependencies": {
-    "@babel/core": "^7",
     "@changesets/cli": "^2.31.0",
     "@wordpress/eslint-plugin": "^25.0.0",
     "@wordpress/stylelint-config": "^23.0.0",


### PR DESCRIPTION
## Why

`@babel/core` was a direct root `devDependency` (`^7`), but it is a **peer** of both `@wordpress/eslint-plugin` (`>=7`) and its `@babel/eslint-parser` (`^7.11.0`) — and bundled by neither. So npm 7+ **auto-installs** it anyway; we don't need to pin it ourselves.

Keeping the direct entry only created a maintenance liability: Dependabot kept proposing `@babel/core@8` (#265), which **can never resolve** because `@babel/eslint-parser`'s peer caps it below 8. Removing the direct dep lets the version follow WordPress's peer ranges (stays on the latest 7.x) and drops that recurring false-positive.

## Verified

- `npm install` → no unmet-peer warnings; `@babel/core` resolves to `7.29.7` and stays in the lockfile (so `npm ci` is still deterministic).
- `npm run lint-js` (dogfood) and all smoke tests pass.

## Note

`npm install` also synced the lockfile's **workspace versions** (`6.0.1` → `7.0.0-alpha.0`) and the widened `eslint` peer, which the `7.0.0-alpha.0` release bump had left stale in the lockfile. Harmless here, but the release step should regenerate the lockfile after `changeset version` so this doesn't drift every release — tracked as a separate follow-up.

Makes Dependabot #265 obsolete.
