### PR TITLE
stylelint-config: raise @wordpress/stylelint-config peer to ^24

### DIFF
--- a/.changeset/stylelint-config-wp-24.md
+++ b/.changeset/stylelint-config-wp-24.md
@@ -1,0 +1,5 @@
+---
+"@wearerequired/stylelint-config": major
+---
+
+Raise the `@wordpress/stylelint-config` peer dependency from `^23` to `^24`. `24.0.0` is a drop-in for our purposes — it keeps the same `stylelint` (`^16.8.2`) and `stylelint-scss` (`^6.4.0`) peers and the same `.`, `/scss`, `/stylistic` and `/scss-stylistic` exports. Verified against required's stylistic overrides (`@stylistic/max-line-length` etc.) and the BEM `selector-class-pattern`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@babel/core": "^7",
         "@changesets/cli": "^2.31.0",
         "@wordpress/eslint-plugin": "^25.0.0",
-        "@wordpress/stylelint-config": "^23.0.0",
+        "@wordpress/stylelint-config": "^24.0.0",
         "eslint": "^9.0.0",
         "prettier": "npm:wp-prettier@3.0.3",
         "stylelint": "^16.8.2",
@@ -3386,20 +3386,20 @@
       }
     },
     "node_modules/@wordpress/compose": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.3.0.tgz",
-      "integrity": "sha512-nHrV8mLanqnLO67l+6RkotG9eRgiW1D6uVb919z8wVWwoZVfimFyN1nznH92tdE/xW6SnX37XDoLoLcS9IkwhQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.4.0.tgz",
+      "integrity": "sha512-oVmRQ05Rlzh+W7oFb6CGmNm9SDozd3VEVYhXO4CcTpz0vkn7bEcwIMIdaKq49X8vORW1htJa/myBbYJATpamNg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.50.0",
-        "@wordpress/dom": "^4.50.0",
-        "@wordpress/element": "^8.2.0",
-        "@wordpress/is-shallow-equal": "^5.50.0",
-        "@wordpress/keycodes": "^4.50.0",
-        "@wordpress/priority-queue": "^3.50.0",
-        "@wordpress/private-apis": "^1.50.0",
-        "@wordpress/undo-manager": "^1.50.0",
+        "@wordpress/deprecated": "^4.51.0",
+        "@wordpress/dom": "^4.51.0",
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/is-shallow-equal": "^5.51.0",
+        "@wordpress/keycodes": "^4.51.0",
+        "@wordpress/priority-queue": "^3.51.0",
+        "@wordpress/private-apis": "^1.51.0",
+        "@wordpress/undo-manager": "^1.51.0",
         "change-case": "^4.1.2",
         "mousetrap": "^1.6.5",
         "use-memo-one": "^1.1.1"
@@ -3409,8 +3409,8 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3419,12 +3419,12 @@
       }
     },
     "node_modules/@wordpress/deprecated": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.50.0.tgz",
-      "integrity": "sha512-TVJavTbunFoCSo2g64EKtGwmDVJhvlSqsc4T1EM4aBwsYGIJPjHcAzh6KS8Z171QXFnBxZ7We8CCDAvOFU9iaA==",
+      "version": "4.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.51.0.tgz",
+      "integrity": "sha512-6pgnUvz7oQRwpJh+aM/dPBs5GBPTyOj+XKGeyzKPKHqbaWeSzkHVI9bhgs+Ajamn/jERK5TgH+VAq/gwfvfO+g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.50.0"
+        "@wordpress/hooks": "^4.51.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -3432,12 +3432,12 @@
       }
     },
     "node_modules/@wordpress/dom": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.50.0.tgz",
-      "integrity": "sha512-2Mognc1rwe1+tlIfbSeZPqbuAh6vJagELzw9cLasObiVayWhaG+LCIp0sJz2pPG9ppz8L31gGUgna7zrSRu85Q==",
+      "version": "4.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.51.0.tgz",
+      "integrity": "sha512-POkQoNBzLFlHaVzJakgF5X/xj4nERsLa5uTAvt3i7YFr9tep3uLtOFCJiiZM1vzO5iVtYSBWxmWyDkJPsOSy6g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.50.0"
+        "@wordpress/deprecated": "^4.51.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -3445,15 +3445,15 @@
       }
     },
     "node_modules/@wordpress/element": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.2.0.tgz",
-      "integrity": "sha512-cTnKRHUdZbYAd4RaJiUwhDKdQDDWY7VoGiwektCmhiBQF6WTFYlhsxl/dmHE0Sok3q7PJQwAg538XEb8WuTaew==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.3.0.tgz",
+      "integrity": "sha512-D6Oawyq9RNL01RbpmBkx5dcE2CawU7p2cPxfeNVZkh/zEV5w9pi7HAwvFFqQA1jRT0sV4B62JcAAzuILALcQQw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/deprecated": "^4.50.0",
-        "@wordpress/escape-html": "^3.50.0",
+        "@wordpress/deprecated": "^4.51.0",
+        "@wordpress/escape-html": "^3.51.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.1",
@@ -3465,9 +3465,9 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "3.50.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.50.0.tgz",
-      "integrity": "sha512-EECt++WB1RNPQBwBS7/6rKO4eUNq2xe6nb6Guv6uT+F74DgtM3+aZtNs7JhKFxRMORPtu7T0LhlAOBa4H5CsPQ==",
+      "version": "3.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.51.0.tgz",
+      "integrity": "sha512-0jPCm9WqpB7S+mdhkjjikBzGo06xAgvmgwtSP1v44P5tKNGujcbsvKj+JW0m60FJxNBmaZPvGu2e/DlY4iljVQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -3566,9 +3566,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
-      "integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+      "version": "4.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.51.0.tgz",
+      "integrity": "sha512-pTVZRT9mjEdrNNt7TyKw5hQhFUqntfTXVs/fboEDpmAi+PFWXoD8rPs3oZyRCVr/MDyE6OCv1mwEibI6AsRk3Q==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -3576,13 +3576,13 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
-      "integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.24.0.tgz",
+      "integrity": "sha512-K4XmCyyyDOKH/5ea75P2L36ZiAvQTy4Hsa73Na3n6NzVjAwrrKZm4JJGf0t+OlThUG4D4GyfEv5szs5EeCA0lA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.50.0",
+        "@wordpress/hooks": "^4.51.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
@@ -3596,9 +3596,9 @@
       }
     },
     "node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.50.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.50.0.tgz",
-      "integrity": "sha512-Cq1brW/OhGVNnCqSztHgmKQ1DsNUtEq4F1xIo1awBKVmXDWFggJRxzaWZHWC+sDZmBp7pu03jWqq2u/s+hazSQ==",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.51.0.tgz",
+      "integrity": "sha512-Ivyf85r9trFfl/rRaDMgghFZ+gzw8yIl7/vDPagYkvq9Xnqw8KecPy91BqIIvco1jIOh3RXPP6cbVu3dTqZDMA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -3606,19 +3606,19 @@
       }
     },
     "node_modules/@wordpress/keycodes": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.50.0.tgz",
-      "integrity": "sha512-BtyCkA7pk5pMMx+dVjT10OuhQwr9ZjYY1LLcXJcYJjhhFsP16be2BiytrBnKDZj/479/icvEYwlooawZCPrxYQ==",
+      "version": "4.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.51.0.tgz",
+      "integrity": "sha512-C9CZq2WCWVacjsHhFgM0GVIQmTUxo/oX7U+Qj0kr3vWHZu6cmEDJ94PX+f02M3b+iHnCk4oHCvnXGANwKQwsSw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.23.0"
+        "@wordpress/i18n": "^6.24.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
-        "@types/react": "^18.3.27"
+        "@types/react": "^18 || ^19"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3640,9 +3640,9 @@
       }
     },
     "node_modules/@wordpress/priority-queue": {
-      "version": "3.50.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.50.0.tgz",
-      "integrity": "sha512-OyuAplepKQpNYr8z+nGGGNXWK2v2u9Bqnawkg7V5YkvOKYj/iBJNCiUxiWXOBMeLF1ze36RDR5LEcNDmXRev2Q==",
+      "version": "3.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.51.0.tgz",
+      "integrity": "sha512-Mgm6DFRW4ZqgkVTQNe6LdtWzah19u6531Uf1L5q1LwYd/eekKeRsNB9dJnqBg2Kn/jgfPbZnTaHToDvnOZQgcA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -3653,9 +3653,9 @@
       }
     },
     "node_modules/@wordpress/private-apis": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.50.0.tgz",
-      "integrity": "sha512-bCVLL9YuWfnPNNqlhl4eTKPipjWbJ8MzAlasJ/SR+h979MyeMFjNPapxKqsPqnJOhDEVSdCTkRN/Wa+Xk8qFdw==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.51.0.tgz",
+      "integrity": "sha512-x3FeBDGegBAKveYHNmgZgTbEwuwVMxGouTR2fKP94Myn5PzF5EkZK1CZJrDnfNjzTl73nCwsd4IXACdtYfnnAQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -3673,18 +3673,18 @@
       }
     },
     "node_modules/@wordpress/stylelint-config": {
-      "version": "23.42.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.42.0.tgz",
-      "integrity": "sha512-k9lNU4sK3fdipdhHI2d/Rzd/NnfznPmOZ60ok8O8QhfCMZw2Jd1M8ckYqaIrHTKU62ZrcsugdfJlHodsdrxEzA==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-24.0.0.tgz",
+      "integrity": "sha512-KmDPgStzIeQFsu1ja8WpZ1ahXg/P5ZKavsapG5ls5bEONIsHx0O5Bz9o2iE/M/112nnRkyI3iKv082SGtYr7TQ==",
       "license": "MIT",
       "dependencies": {
-        "@stylistic/stylelint-plugin": "^3.0.1",
-        "@wordpress/theme": "^0.17.0",
+        "@stylistic/stylelint-plugin": "^3.1.3",
+        "@wordpress/theme": "^1.0.0",
         "stylelint-config-recommended": "^14.0.1",
         "stylelint-config-recommended-scss": "^14.1.0"
       },
       "engines": {
-        "node": ">=18.12.0",
+        "node": "^20.19.0 || >=22.13.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
@@ -3692,30 +3692,40 @@
         "stylelint-scss": "^6.4.0"
       }
     },
+    "node_modules/@wordpress/stylelint-config/node_modules/@wordpress/style-runtime": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.7.0.tgz",
+      "integrity": "sha512-PeAcF7qoIMg9ChS5SfkRrLLcUx9D7Te6weRcQmoKYgxE7jSzzXpoaiy3Z+Us+ChyisolF4xhTg5DblMBPL1iug==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
     "node_modules/@wordpress/stylelint-config/node_modules/@wordpress/theme": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.17.0.tgz",
-      "integrity": "sha512-BU+PLBLxMBM4WJYrd1QEwy+IA64vUP+8IEEB9lLx2NfB+3/45vvuvXx9o3qPKRDHvtMtEaRArld4Kn05UIW9IA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-1.0.0.tgz",
+      "integrity": "sha512-zPwDgv7xx3f4h+lLCq95szofMAMjSIlkIIfR7U2cxQws5J6XnnTsOxHWJTE6V4jPzS19vzFdQdZ9wiR/X3c0Lw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
+        "@wordpress/compose": "^8.4.0",
+        "@wordpress/deprecated": "^4.51.0",
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/private-apis": "^1.51.0",
+        "@wordpress/style-runtime": "^0.7.0",
         "colorjs.io": "^0.6.0",
         "memize": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
+        "node": "^20.19.0 || >=22.13.0",
+        "npm": ">=10.2.3"
       },
       "peerDependencies": {
-        "@types/react": "^18.3.27",
+        "@types/react": "^18 || ^19",
         "esbuild": "^0.27.2",
         "postcss": "^8.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
         "stylelint": "^16.8.2",
         "vite": "^7.3.2"
       },
@@ -3738,12 +3748,12 @@
       }
     },
     "node_modules/@wordpress/undo-manager": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.50.0.tgz",
-      "integrity": "sha512-599I3GPXSMpmAE2jqzHteqypI7rdt5HPDAw8GrHMkDWR1T9gK2L3gObv8I1Hs4eSDM88wgAB0Ifnqpy7zPn5rw==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.51.0.tgz",
+      "integrity": "sha512-w/vUyQX2m+X2xDYCdxu/ALHJdE5S0vkWbxFhUJJeBJG66IFs/DGk/NmLCOudUFLFMQYSXFyIm1XsIPT0UdjhCA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/is-shallow-equal": "^5.50.0"
+        "@wordpress/is-shallow-equal": "^5.51.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9590,23 +9600,23 @@
     },
     "packages/eslint-config": {
       "name": "@wearerequired/eslint-config",
-      "version": "6.0.1",
+      "version": "7.0.0-alpha.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "globals": "^16.0.0"
       },
       "peerDependencies": {
         "@wordpress/eslint-plugin": "^25.0.0",
-        "eslint": "^9.0.0",
+        "eslint": "^9.0.0 || ^10.0.0",
         "prettier": ">=3"
       }
     },
     "packages/stylelint-config": {
       "name": "@wearerequired/stylelint-config",
-      "version": "6.0.1",
+      "version": "7.0.0-alpha.0",
       "license": "GPL-2.0-or-later",
       "peerDependencies": {
-        "@wordpress/stylelint-config": "^23",
+        "@wordpress/stylelint-config": "^24",
         "stylelint": "^16.8.2",
         "stylelint-scss": "^6.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7",
     "@changesets/cli": "^2.31.0",
     "@wordpress/eslint-plugin": "^25.0.0",
-    "@wordpress/stylelint-config": "^23.0.0",
+    "@wordpress/stylelint-config": "^24.0.0",
     "eslint": "^9.0.0",
     "prettier": "npm:wp-prettier@3.0.3",
     "stylelint": "^16.8.2",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/wearerequired/coding-standards/tree/master/packages/stylelint-config#readme",
   "peerDependencies": {
-    "@wordpress/stylelint-config": "^23",
+    "@wordpress/stylelint-config": "^24",
     "stylelint": "^16.8.2",
     "stylelint-scss": "^6.4.0"
   },


### PR DESCRIPTION
## Why #266 was red

Dependabot #266 bumped the root devDependency `@wordpress/stylelint-config` to `24.0.0`, but our published `@wearerequired/stylelint-config` still declared a `^23` peer. `npm ci` then failed with **ERESOLVE** (peer `^23` vs. found `24.0.0`) — before any test ran.

## What #266 needs to go green

1. **Raise the peer** `@wordpress/stylelint-config` `^23` → `^24` in `packages/stylelint-config/package.json` (the actual ERESOLVE fix).
2. **Bump the root devDependency** to `^24` + refresh the lockfile.
3. **A dedicated changeset** (major) — the stylelint-16 migration changeset is already consumed by `7.0.0-alpha.0`, so editing it wouldn't trigger a release.

Dependabot can only do #2, which is why its PR can't be green on its own.

## Compatibility — verified

`24.0.0` is a drop-in: identical `stylelint` (`^16.8.2`) and `stylelint-scss` (`^6.4.0`) peers (no jump to stylelint 17) and the same exports. The stylelint smoke tests — including the `@stylistic/max-line-length` and BEM `selector-class-pattern` overrides — pass against 24.

Supersedes #266.
