### PR TITLE
Sync the lockfile as part of version-packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9590,20 +9590,20 @@
     },
     "packages/eslint-config": {
       "name": "@wearerequired/eslint-config",
-      "version": "6.0.1",
+      "version": "7.0.0-alpha.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "globals": "^16.0.0"
       },
       "peerDependencies": {
         "@wordpress/eslint-plugin": "^25.0.0",
-        "eslint": "^9.0.0",
+        "eslint": "^9.0.0 || ^10.0.0",
         "prettier": ">=3"
       }
     },
     "packages/stylelint-config": {
       "name": "@wearerequired/stylelint-config",
-      "version": "6.0.1",
+      "version": "7.0.0-alpha.0",
       "license": "GPL-2.0-or-later",
       "peerDependencies": {
         "@wordpress/stylelint-config": "^23",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:js": "bash tests/eslint/run.sh",
     "test:css": "bash tests/stylelint/run.sh",
     "changeset": "changeset",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && npm install --package-lock-only",
     "release": "changeset publish"
   }
 }


### PR DESCRIPTION
## Problem

The release step runs `npm run version-packages`, which is just:

```json
"version-packages": "changeset version"
```

`changeset version` bumps each package's `package.json` and writes the changelogs, but **does not touch `package-lock.json`**. The lockfile keeps a `version` field per workspace package, so after every release it drifts from `package.json`. The `7.0.0-alpha.0` release left the committed lockfile with:

- `packages/eslint-config` → `6.0.1` (package.json: `7.0.0-alpha.0`), eslint peer `^9.0.0` (package.json: `^9.0.0 || ^10.0.0`)
- `packages/stylelint-config` → `6.0.1`

`npm ci` tolerates the workspace self-version drift, but every feature branch that runs `npm install` "catches up" the sync, so its lockfile diff carries unrelated version bumps as noise (seen in #267 / #268 / #270).

## Fix

```json
"version-packages": "changeset version && npm install --package-lock-only"
```

`--package-lock-only` rewrites the lockfile from the freshly bumped `package.json` files **without** installing `node_modules` — cheap, and it runs after the release job's existing `npm ci`. `changesets/action` then commits the synced lockfile into the "Version Packages" PR, so lockfile and versions stay in step from here on.

Must live on `master`: the release workflow reads `version-packages` from the base branch.

## Also in this PR

Applied the pending sync so master's lockfile is correct immediately. The lockfile diff is metadata only (workspace versions + eslint peer) — no transitive churn.

## Verified

`npm ci` installs cleanly from the synced lockfile and the smoke tests pass.
