### PR TITLE
Group Dependabot updates and guard against missing changesets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,16 @@ updates:
       time: "06:00"
       timezone: "Europe/Zurich"
     open-pull-requests-limit: 3
+    # Collapse the interrelated lint toolchain (they share peer ranges and are
+    # usually reviewed together) into one weekly PR instead of one per package.
+    groups:
+      wordpress-lint-toolchain:
+        patterns:
+          - "@wordpress/*"
+          - "eslint*"
+          - "stylelint*"
+          - "prettier"
+          - "typescript"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -24,3 +34,8 @@ updates:
       time: "06:00"
       timezone: "Europe/Zurich"
     open-pull-requests-limit: 3
+    # Action bumps are low-risk and frequent — batch them into one PR.
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,13 @@ jobs:
           BASE: ${{ github.base_ref }}
         run: |
           git fetch --no-tags origin "$BASE"
-          changed=$(git diff --name-only "origin/${BASE}...HEAD")
-          manifest_changed=$(echo "$changed" | grep -E '^packages/[^/]+/package\.json$' || true)
-          changeset_added=$(echo "$changed" | grep -E '^\.changeset/.+\.md$' | grep -vE '^\.changeset/README\.md$' || true)
+          manifest_changed=$(git diff --name-only "origin/${BASE}...HEAD" \
+            | grep -E '^packages/[^/]+/package\.json$' || true)
+          # Only a newly ADDED changeset counts — editing an existing one does
+          # not version a new change (and in pre mode does not trigger a release).
+          changeset_added=$(git diff --name-status "origin/${BASE}...HEAD" \
+            | awk '$1 ~ /^A/ { print $2 }' \
+            | grep -E '^\.changeset/.+\.md$' | grep -vE '^\.changeset/README\.md$' || true)
           if [ -n "$manifest_changed" ] && [ -z "$changeset_added" ]; then
             echo "::error::A published package's package.json changed but this PR adds no changeset. Run 'npx changeset' (or 'npx changeset --empty' if there is genuinely no consumer impact)."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,35 @@ jobs:
       - name: Smoke tests (eslint-config + stylelint-config)
         run: npm test
 
+  changeset-guard:
+    name: Changeset guard
+    # Only on PRs (a push to master has no base to diff against), and skip the
+    # changesets "Version Packages" PR, which intentionally removes changesets.
+    if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      # A change to a published package's manifest (version, dependencies,
+      # peers) is consumer-facing and must ship with a changeset. Catches the
+      # class of change Dependabot or a quick fix can miss — e.g. bumping a peer
+      # in packages/*/package.json without recording it (see the v7 alphas).
+      - name: Require a changeset when a published package's manifest changes
+        env:
+          BASE: ${{ github.base_ref }}
+        run: |
+          git fetch --no-tags origin "$BASE"
+          changed=$(git diff --name-only "origin/${BASE}...HEAD")
+          manifest_changed=$(echo "$changed" | grep -E '^packages/[^/]+/package\.json$' || true)
+          changeset_added=$(echo "$changed" | grep -E '^\.changeset/.+\.md$' | grep -vE '^\.changeset/README\.md$' || true)
+          if [ -n "$manifest_changed" ] && [ -z "$changeset_added" ]; then
+            echo "::error::A published package's package.json changed but this PR adds no changeset. Run 'npx changeset' (or 'npx changeset --empty' if there is genuinely no consumer impact)."
+            exit 1
+          fi
+          echo "Changeset guard OK."
+
   php:
     name: PHP ${{ matrix.php }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to the Dependabot/changeset discussion. Instead of the auto-changeset writer (which would be **dormant** in this repo — the published packages have no runtime `dependencies`, so Dependabot only bumps root dev tooling + composer, and the real changesets we needed were human judgment calls), this adds the two things that actually help.

## (a) Dependabot grouping — less PR noise

- **npm**: group the interrelated lint toolchain (`@wordpress/*`, `eslint*`, `stylelint*`, `prettier`, `typescript`) into **one** weekly PR instead of one per package (the #263–#266 wave would have been ~1 PR).
- **github-actions**: batch all action bumps into one PR.
- **composer**: left **ungrouped** on purpose — the PHP stack is exact-pinned and each bump is a deliberate review against the PHP_CodeSniffer 3 ceiling (WPCS/slevomat), so mixing them would hide risk.

## (b) Changeset guard — catch the real cases

A new `changeset-guard` CI job fails a PR when a **published package's `package.json`** changes but no **newly added** changeset is present — exactly the peer/dependency class we fixed by hand in the v7 alphas (globals removal #267, `@wordpress/stylelint-config ^24` #266). It forces the *right* changeset rather than guessing one.

- Scoped to `packages/*/package.json` → stays quiet for root dev-tooling bumps, composer, and docs.
- Requires an **added** (`A`) `.changeset/*.md` — an *edited* existing changeset doesn't count, since editing one doesn't version a new change (and in pre mode doesn't trigger a release).
- Skips `push` events and the changesets `Version Packages` PR (which intentionally removes changesets).

Verified locally against these diff scenarios (the `package.json` below is always a **published** `packages/*/package.json`):

| Diff | Result |
| ---- | ------ |
| manifest changed, no changeset | **fail** |
| manifest changed + newly added changeset | pass |
| manifest changed + only an *edited* existing changeset | **fail** |
| manifest changed + only `.changeset/README.md` | **fail** |
| root devDependency bump only (no `packages/*/package.json`) | pass |
| docs-only change | pass |

> To enforce it, add **Changeset guard** to the branch-protection required checks for `master`.
