### PR TITLE
Dependabot: ignore lint-toolchain majors beyond the WordPress ceiling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,21 @@ updates:
           - "stylelint*"
           - "prettier"
           - "typescript"
+    # The WordPress toolchain caps these majors: @wordpress/stylelint-config 24
+    # requires stylelint ^16 (stylelint-scss stays on the matching 6.x line),
+    # typescript-eslint does not support TypeScript 7 yet, and a standalone
+    # ESLint 10 breaks eslint-plugin-import's TypeScript resolver (this repo
+    # dogfoods ESLint directly, not via @wordpress/scripts). Bump these majors
+    # manually once WordPress moves.
+    ignore:
+      - dependency-name: "stylelint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "stylelint-scss"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Why

The grouped toolchain PR #273 fails `npm ci` with **ERESOLVE**:

```
peer stylelint@"^16.8.2" from @wordpress/stylelint-config@24.0.0
Found: stylelint@17.14.0  →  Conflicting peer dependency
```

Dependabot bumped `stylelint` to 17 (and `stylelint-scss` to 7), but `@wordpress/stylelint-config@24` still requires `stylelint ^16.8.2` — WordPress has not moved to stylelint 17. The same group also proposed **TypeScript 7** (typescript-eslint caps it well below) and **ESLint 10** (which breaks `eslint-plugin-import`'s TypeScript resolver when ESLint is installed standalone, as this repo dogfoods it — consumers get ESLint 10 support only via `@wordpress/scripts`).

## Fix

Ignore the **semver-major** updates for these four packages in `.github/dependabot.yml`, so Dependabot stops proposing versions the WordPress toolchain can't resolve:

- `stylelint` (capped at ^16 by `@wordpress/stylelint-config`)
- `stylelint-scss` (stays on the matching 6.x line)
- `typescript` (typescript-eslint has no TS 7 support yet)
- `eslint` (standalone ESLint 10 breaks the import resolver)

Minors/patches still flow through — e.g. `@wordpress/eslint-plugin 25.7.0`, the only safe update in #273. We bump these majors manually once WordPress catches up.

## Follow-up for #273

Once this merges, `@dependabot recreate` on #273 regenerates the group without the four majors (leaving just `@wordpress/eslint-plugin 25.7.0`, which is green).
