### PR TITLE
Update @wordpress/eslint-plugin to 25.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3340,9 +3340,9 @@
       "link": true
     },
     "node_modules/@wordpress/babel-preset-default": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.50.0.tgz",
-      "integrity": "sha512-nXF+cu0NA9lk4GPO+/iv3mMt1TV9zzjMalfaNPfafWz5VDGW68h82Le8wqclTewex/99kYWl12kHwDIx66hw6Q==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.51.0.tgz",
+      "integrity": "sha512-blv2dA2gH9XzD71jiX5rI68Xjioais+n4UC8+wSVcGmHzcVuOHta/serOD8nYzQL0+HOv59O29uzXGONKDWzNg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/core": "^7.25.7",
@@ -3351,9 +3351,9 @@
         "@babel/plugin-transform-runtime": "^7.25.7",
         "@babel/preset-env": "^7.25.7",
         "@babel/preset-typescript": "^7.25.7",
-        "@wordpress/browserslist-config": "^6.50.0",
-        "@wordpress/warning": "^3.50.0",
-        "browserslist": "^4.21.10",
+        "@wordpress/browserslist-config": "^6.51.0",
+        "@wordpress/warning": "^3.51.0",
+        "browserslist": "^4.28.4",
         "core-js": "^3.31.0",
         "react": "^18.3.1"
       },
@@ -3363,9 +3363,9 @@
       }
     },
     "node_modules/@wordpress/browserslist-config": {
-      "version": "6.50.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.50.0.tgz",
-      "integrity": "sha512-/5Zn/uIvVw37iLJRa/HhqHQ/DJq4KWjEXTkFQ/NpCNFQm6ll54uDgYZ9f0tWQM7ORCzCU32z/IJ8ujZaMLA9nQ==",
+      "version": "6.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.51.0.tgz",
+      "integrity": "sha512-/siYL1d2O/evfWkXIDuhIVfHHBYE0T8hiD4JD8xm6JGe9Z2zHikveVT/AvJZrIzUBJknEIADyFE+cXimk97GkA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -3462,17 +3462,17 @@
       }
     },
     "node_modules/@wordpress/eslint-plugin": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-25.6.0.tgz",
-      "integrity": "sha512-TZ1M+S8gk0MltuF2WsiNG4sjIUvaurB036v4QL81HM3DsfjPFOpKykyWswWO/iZv/e0f/ryG4O/aDfMbU+oEHg==",
+      "version": "25.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-25.7.0.tgz",
+      "integrity": "sha512-OY22qfNDQjBJ5Y4OWiEPhCPp0KGaGWr0kRK05e1Kh73ps2XEv8yyp74EJdkxqqog8R/W7mLH+RB/YogY5fUHMg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/eslint-parser": "^7.28.6",
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.0",
         "@eslint/compat": "^2.0.0",
-        "@wordpress/babel-preset-default": "^8.50.0",
-        "@wordpress/prettier-config": "^4.50.0",
-        "@wordpress/theme": "^0.17.0",
+        "@wordpress/babel-preset-default": "^8.51.0",
+        "@wordpress/prettier-config": "^4.51.0",
+        "@wordpress/theme": "^1.0.0",
         "cosmiconfig": "^7.0.0",
         "eslint-config-prettier": "^10.0.0",
         "eslint-import-resolver-typescript": "^4.4.4",
@@ -3508,29 +3508,29 @@
       }
     },
     "node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/theme": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.17.0.tgz",
-      "integrity": "sha512-BU+PLBLxMBM4WJYrd1QEwy+IA64vUP+8IEEB9lLx2NfB+3/45vvuvXx9o3qPKRDHvtMtEaRArld4Kn05UIW9IA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-1.0.0.tgz",
+      "integrity": "sha512-zPwDgv7xx3f4h+lLCq95szofMAMjSIlkIIfR7U2cxQws5J6XnnTsOxHWJTE6V4jPzS19vzFdQdZ9wiR/X3c0Lw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
+        "@wordpress/compose": "^8.4.0",
+        "@wordpress/deprecated": "^4.51.0",
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/private-apis": "^1.51.0",
+        "@wordpress/style-runtime": "^0.7.0",
         "colorjs.io": "^0.6.0",
         "memize": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
+        "node": "^20.19.0 || >=22.13.0",
+        "npm": ">=10.2.3"
       },
       "peerDependencies": {
-        "@types/react": "^18.3.27",
+        "@types/react": "^18 || ^19",
         "esbuild": "^0.27.2",
         "postcss": "^8.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
         "stylelint": "^16.8.2",
         "vite": "^7.3.2"
       },
@@ -3614,9 +3614,9 @@
       }
     },
     "node_modules/@wordpress/prettier-config": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.50.0.tgz",
-      "integrity": "sha512-Q48oFBORY0TiVWIebPOG0ynjUAq1Hi9gXKJ69xw2i/UwOwghLOXXFLdAQhS4bJXOw0cdV5xiBaXEQYU+82r5hA==",
+      "version": "4.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.51.0.tgz",
+      "integrity": "sha512-V6bsx/WImZmxaiMG7DOA4z8G76eFxlmJ/ZqZRN7tAja7jHPfliuRtCZI2CJBx0c0fT3zGsq8xkC4bmDlMra65A==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -3650,9 +3650,9 @@
       }
     },
     "node_modules/@wordpress/style-runtime": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.5.0.tgz",
-      "integrity": "sha512-hrXvdDUJpOzT1KIomgtysysgbc5bkkwAuJyEUAXiOCgVBXBeMkZlgfN19W0PuNY51j53K7VQ42txfayxgVmfgA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.7.0.tgz",
+      "integrity": "sha512-PeAcF7qoIMg9ChS5SfkRrLLcUx9D7Te6weRcQmoKYgxE7jSzzXpoaiy3Z+Us+ChyisolF4xhTg5DblMBPL1iug==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=20.10.0",
@@ -3677,16 +3677,6 @@
       "peerDependencies": {
         "stylelint": "^16.8.2",
         "stylelint-scss": "^6.4.0"
-      }
-    },
-    "node_modules/@wordpress/stylelint-config/node_modules/@wordpress/style-runtime": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.7.0.tgz",
-      "integrity": "sha512-PeAcF7qoIMg9ChS5SfkRrLLcUx9D7Te6weRcQmoKYgxE7jSzzXpoaiy3Z+Us+ChyisolF4xhTg5DblMBPL1iug==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
       }
     },
     "node_modules/@wordpress/stylelint-config/node_modules/@wordpress/theme": {
@@ -3748,9 +3738,9 @@
       }
     },
     "node_modules/@wordpress/warning": {
-      "version": "3.50.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.50.0.tgz",
-      "integrity": "sha512-6X3ioKOGfmRuZFngmG2QZZW9CBVMTBr5FXqs6Q3li5ryhnAqn3u/ocqsx556YnB5dYdVxK14TiH9o7DDElt8gw==",
+      "version": "3.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.51.0.tgz",
+      "integrity": "sha512-wWeM6pjAWbMhdNfgCaxi5yhLzomj6/trcIjGPi2Q4kaIuxUula8Ybq0ZPn5lYuc19ICkcGYcAnWNYz/4mYCHdA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",


### PR DESCRIPTION
The one safe, in-range update from the toolchain group #273. The four majors in that group (stylelint 17, stylelint-scss 7, typescript 7, eslint 10) are now ignored via #275 as unsupported by the WordPress toolchain.

- **Lockfile-only**: `package.json` already allows `^25.0.0`, so only `package-lock.json` changes (`@wordpress/eslint-plugin` 25.6.0 → 25.7.0, plus deduped transitives).
- Verified: `npm ci` installs cleanly, `npm run lint-js` (dogfood) and `npm test` pass.

Applied manually because `@dependabot recreate` on #273 didn't regenerate the PR after #275 merged. Supersedes #273.
