### PR TITLE
Exit Changesets pre mode for the stable 7.0.0 release

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "alpha",
   "initialVersions": {
     "@wearerequired/eslint-config": "6.0.1",


### PR DESCRIPTION
Step 1 of the stable **7.0.0** release: leave Changesets pre mode.

Sets `.changeset/pre.json` to `mode: exit`. Both packages are currently at `7.0.0-alpha.1`.

## What happens on merge

The Release workflow runs `changeset version`, which:
- aggregates the four pending major changesets (2× `@wearerequired/eslint-config`, 2× `@wearerequired/stylelint-config`) into the stable **`7.0.0`** for both packages (drops the `-alpha.N` suffix),
- writes each package's `CHANGELOG.md`,
- removes `.changeset/pre.json`,
- syncs the lockfile,
- opens/updates the **"Version Packages"** PR.

Merging that Version Packages PR publishes `7.0.0` to npm on the **`latest`** dist-tag via Trusted Publishing.

## After this
- PHP: tag `7.0.0` (bare, signed) → Packagist; move CHANGELOG `[Unreleased]` → `[7.0.0]`.
