### PR TITLE
Prepare CHANGELOG for the PHP 7.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.0] - 2026-07-19
+
 Dependencies stay pinned to exact versions (as before) so the standard lints reproducibly.
 
 ### Changed
@@ -206,7 +208,8 @@ Dependencies stay pinned to exact versions (as before) so the standard lints rep
 * [VariableAnalysis](https://github.com/sirbrillig/phpcs-variable-analysis) for problematic variable use.
 * [Slevomat Coding Standard](https://github.com/slevomat/coding-standard) for PHP >=7 development.
 
-[Unreleased]: https://github.com/wearerequired/coding-standards/compare/6.0.1...HEAD
+[Unreleased]: https://github.com/wearerequired/coding-standards/compare/7.0.0...HEAD
+[7.0.0]: https://github.com/wearerequired/coding-standards/compare/6.0.1...7.0.0
 [6.0.1]: https://github.com/wearerequired/coding-standards/compare/6.0.0...6.0.1
 [6.0.0]: https://github.com/wearerequired/coding-standards/compare/5.0.0...6.0.0
 [5.0.0]: https://github.com/wearerequired/coding-standards/compare/4.0.0...5.0.0


### PR DESCRIPTION
Step 2 of the stable release: the **PHP** package `wearerequired/coding-standards` 7.0.0.

Promotes the `[Unreleased]` PHP entries to **`[7.0.0]`** (dated), adds a fresh `[Unreleased]` section, and adds the compare links.

## Release flow (after merge)

The PHP package is released by pushing a **signed, bare git tag** on the CHANGELOG commit — Packagist syncs it automatically:

```
git checkout master && git pull --ff-only
git tag -s 7.0.0 -m "Release 7.0.0"
git push origin 7.0.0
```

`7.0.0` (breaking): minimum PHP 7.2 → 7.4, WPCS 3.1 → 3.4, slevomat 8.15 → 8.22.1 (last PHP_CodeSniffer 3 compatible), php_codesniffer pinned 3.13.5, phpcompatibility-wp 2.1.8, variable-analysis 2.13.0; internal: Lerna → npm workspaces + Changesets, CI + smoke tests.
