### PR TITLE
Prepare CHANGELOG for the PHP 7.0.1 security release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.1] - 2026-07-29
+
+### Security
+* PHP: Update `wp-coding-standards/wpcs` from 3.4.0 to [3.4.1](https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/3.4.1), which fixes arbitrary command execution in the `WordPress.WP.EnqueuedResourceParameters` sniff — scanning untrusted PHP (a CI job linting a pull request, or reviewing third-party code locally) could execute code on the scanning host.
+  [CVE-2026-45293](https://github.com/WordPress/WordPress-Coding-Standards/security/advisories/GHSA-3pwp-g2mj-5p3v) / CWE-95, CVSS 8.6 (high). **Both `Required` and `Required-Strict` include `WordPress-Extra` and were affected — update as soon as possible.**
+  Transitively raises `phpcsstandards/phpcsutils` to 1.2.3 and `phpcsstandards/phpcsextra` to 1.5.1.
+
+  Note that 7.0.0 pinned the vulnerable `wpcs` 3.4.0 exactly, so Composer 2.10+ refuses to resolve it at all (`policy.advisories.block` defaults to on) — 7.0.1 is required for `composer update` to succeed, not just for the fix.
+
 ## [7.0.0] - 2026-07-19
 
 Dependencies stay pinned to exact versions (as before) so the standard lints reproducibly.
@@ -208,7 +217,8 @@ Dependencies stay pinned to exact versions (as before) so the standard lints rep
 * [VariableAnalysis](https://github.com/sirbrillig/phpcs-variable-analysis) for problematic variable use.
 * [Slevomat Coding Standard](https://github.com/slevomat/coding-standard) for PHP >=7 development.
 
-[Unreleased]: https://github.com/wearerequired/coding-standards/compare/7.0.0...HEAD
+[Unreleased]: https://github.com/wearerequired/coding-standards/compare/7.0.1...HEAD
+[7.0.1]: https://github.com/wearerequired/coding-standards/compare/7.0.0...7.0.1
 [7.0.0]: https://github.com/wearerequired/coding-standards/compare/6.0.1...7.0.0
 [6.0.1]: https://github.com/wearerequired/coding-standards/compare/6.0.0...6.0.1
 [6.0.0]: https://github.com/wearerequired/coding-standards/compare/5.0.0...6.0.0

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "sirbrillig/phpcs-variable-analysis": "2.13.0",
     "slevomat/coding-standard": "8.22.1",
     "squizlabs/php_codesniffer": "3.13.5",
-    "wp-coding-standards/wpcs": "3.4.0"
+    "wp-coding-standards/wpcs": "3.4.1"
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "1.2.1"


### PR DESCRIPTION
Documents the `wp-coding-standards/wpcs` 3.4.0 → 3.4.1 bump as a security release. Depends on #282 — merge that first, then this, then push the signed `7.0.1` tag.

## Why this is a security release

[CVE-2026-45293](https://github.com/WordPress/WordPress-Coding-Standards/security/advisories/GHSA-3pwp-g2mj-5p3v) (CWE-95, CVSS 8.6 high): `WordPress.WP.EnqueuedResourceParameters` reconstructed function arguments and ran them through `eval()` in `is_falsy()`. Scanning untrusted PHP — a CI job linting a pull request, or reviewing third-party code locally — could execute arbitrary commands on the scanning host.

**We were exposed in both standards.** `Required/ruleset.xml` includes `WordPress-Extra`, and `Required-Strict` inherits `Required`. Verified with a benign PoC in a throwaway worktree:

| WPCS | `eval(` in sniff | PoC payload executed during scan |
|---|---|---|
| 3.4.0 | 2 occurrences | **yes** |
| 3.4.1 | 0 | no |

## The part that raises urgency

Composer 2.10's `policy.advisories.block` defaults to on, so `composer update` against current `master` fails to resolve at all:

```
- Root composer.json requires wp-coding-standards/wpcs 3.4.0 … not loaded,
  because they are affected by security advisories ("PKSA-mh9b-91zm-m1gy")
```

Because 7.0.0 pins the affected 3.4.0 exactly, the released package is **uninstallable** for consumers on Composer 2.10+, not merely vulnerable. Shipping 7.0.1 is what unblocks `composer update`.

## Verification

With #282 applied: dependencies resolve cleanly (pulling PHPCSUtils 1.2.3, PHPCSExtra 1.5.1) and `composer test` passes all four smoke assertions across `Required` and `Required-Strict`.

## Follow-up

The exact-pin policy is worth a separate discussion — an upstream *patch* now requires a coordinated release here, and blocks consumers until it lands. Filed separately; no constraint change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)